### PR TITLE
Setup: Include template *.yaml files in output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,9 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     package_dir={"": "src"},
+    package_data={
+        '': ['**/*.yaml']
+    },
     packages=setuptools.find_packages(where="src"),
     python_requires=">=3.9.0",
     entry_points={},


### PR DESCRIPTION
## Description

**Setup: Include template YAML files in package**
* Include `src/template/*.yaml` files in the output

PTAL: @ankrgyl @davidatbraintrust 

## Testing

* Ran `make build` locally.
* Installed package locally in a vanilla pipenv to ensure evaluator loads
```
# Create a new env
> PIPENV_VENV_IN_PROJECT=1 pipenv install --python 3.9
# Activate shell
> pipenv shell
# Install package via tar.gz generated from previous step
> pip install <path to the tar.gz>/autoevals-0.0.2.tar.gz
# Load Python & confirmed the evaluators loads
> python
>> from autoevals import llm
>> evaluator = llm.Summary()
```
* Manually inspect SCRIPT_DIR of the install from tar.gz to ensure templates are included.