### PR TITLE
Package uses cjs for commonjs, so .js needs to be module

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Universal library for evaluating AI models",
   "main": "jsdist/bundle.js",
   "types": "jsdist/index.d.ts",
+  "type": "module",
   "exports": {
     "node": {
       "types": "./jsdist/node.d.ts",


### PR DESCRIPTION
Change `type` to `module` so that node can load the module and the commonjs module 

![image](https://github.com/braintrustdata/autoevals/assets/342540/d07ddd79-3fa8-43a7-aae4-5437e9283814)
