### PR TITLE
Add file extensions for true ESM

### DIFF
--- a/js/index.ts
+++ b/js/index.ts
@@ -27,7 +27,7 @@
  * @module autoevals
  */
 
-export * from "./base";
-export * from "./llm";
-export * from "./string";
-export * from './templates';
+export * from "./base.js";
+export * from "./llm.js";
+export * from "./string.js";
+export * from './templates.js';

--- a/js/llm.ts
+++ b/js/llm.ts
@@ -1,10 +1,10 @@
 import * as yaml from "js-yaml";
 import mustache from "mustache";
 
-import { Score, Scorer, ScorerArgs } from "./base";
+import { Score, Scorer, ScorerArgs } from "./base.js";
 import { ChatCompletionRequestMessage } from "openai";
-import { ChatCache, cachedChatCompletion } from "./oai";
-import { templates } from "./templates";
+import { ChatCache, cachedChatCompletion } from "./oai.js";
+import { templates } from "./templates.js";
 
 const NO_COT_SUFFIX = `Answer the question by printing only a single choice from {{__choices}} (without quotes or punctuation) corresponding to the correct answer with no other text.`;
 

--- a/js/node.ts
+++ b/js/node.ts
@@ -1,4 +1,4 @@
-import { Env } from "./env";
+import { Env } from "./env.js";
 Env.OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 
-export * from "./index";
+export * from "./index.js";

--- a/js/oai.ts
+++ b/js/oai.ts
@@ -4,7 +4,7 @@ import {
   CreateChatCompletionResponse,
   OpenAIApi,
 } from "openai";
-import { Env } from "./env";
+import { Env } from "./env.js";
 
 export interface CachedLLMParams {
   model: string;

--- a/js/string.test.ts
+++ b/js/string.test.ts
@@ -1,4 +1,4 @@
-import { LevenshteinScorer } from "./string";
+import { LevenshteinScorer } from "./string.js";
 
 test("Basic Test", async () => {
   const cases = [

--- a/js/string.ts
+++ b/js/string.ts
@@ -1,4 +1,4 @@
-import { Scorer } from "./base";
+import { Scorer } from "./base.js";
 import levenshtein from "js-levenshtein";
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,10 @@
     "lib": ["es6"],
     "module": "commonjs",
     "target": "es6",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
   },
   "include": ["js"],
   "exclude": ["node_modules/**"]


### PR DESCRIPTION
Switching to nodenext module resolution means that "type": "module" works better, and true ESM requires file extensions on everything. This fixes TS imports on the package (and it still works using both `import` and `require` at runtime)