### PR TITLE
Github Action: Trigger pre-commit hooks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,5 @@
 # Source: https://github.com/marketplace/actions/pre-commit
-name: pre-commit
+name: lint
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  pre-commit:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,15 @@
+# Source: https://github.com/marketplace/actions/pre-commit
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
> This is blocked until https://github.com/braintrustdata/autoevals/pull/11 is merged.

* Runs pre-commit checks as a part of Github actions.

PTAL: @ankrgyl 

## Notes
* Github Action's doc from Pre-commit maintainers: https://github.com/marketplace/actions/pre-commit
* Demo PR on how it works once the Github Action is setup: https://github.com/dashk/autoevals/pull/1