### PR TITLE
Update link to Autoevals docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,4 +262,4 @@ Nicolo also dropped this as a reference: http://spec.openapis.org/oas/v3.0.3#ope
 
 ## Documentation
 
-The full docs are available [here](https://www.braintrustdata.com/docs/autoevals).
+The full docs are available [here](https://www.braintrustdata.com/docs/autoevals/overview).


### PR DESCRIPTION
* Updated link from `https://www.braintrustdata.com/docs/autoevals/` to `https://www.braintrustdata.com/docs/autoevals/overview`

PTAL: @ankrgyl 