### PR TITLE
Update pydoc-markdown requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ extras_require = {
         "pytest",
         "twine",
     ],
-    "doc": ["pydoc-markdown[novella]"],
+    "doc": ["pydoc-markdown"],
 }
 
 extras_require["all"] = sorted({package for packages in extras_require.values() for package in packages})


### PR DESCRIPTION
To fix the pip warning

```
WARNING: pydoc-markdown 4.8.2 does not provide the extra 'novella'
```

It doesn't look like we use novella anyways.