### PR TITLE
Support multiple openai versions in python

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -18,7 +18,7 @@ jobs:
           python-version: "3.11"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools build twine
+          python -m pip install --upgrade pip setuptools build twine openai
           python -m pip install -e .[dev]
       - name: Test with pytest
         run: |

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+env:
+  OPENAI_API_KEY: sk-dummy
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/py/autoevals/llm.py
+++ b/py/autoevals/llm.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 import chevron
-import openai
 import yaml
 
 from .base import Score, Scorer
@@ -140,8 +139,8 @@ class OpenAILLMClassifier(Scorer):
         if self.engine is not None:
             # This parameter has been deprecated (https://help.openai.com/en/articles/6283125-what-happened-to-engines)
             # and is unsupported in OpenAI v1, so only set it if the user has specified it
-            ret['engine'] = self.engine
-        
+            ret["engine"] = self.engine
+
         return ret
 
     def _postprocess_response(self, resp):
@@ -168,8 +167,6 @@ class OpenAILLMClassifier(Scorer):
             return self._postprocess_response(run_cached_request(**self._request_args(output, expected, **kwargs)))
         except Exception as e:
             validity_score = 0
-            import traceback
-            traceback.print_exc()
             return Score(name=self.name, score=0, error=e)
         finally:
             current_span().log(scores={f"{self._name()} parsed": validity_score})

--- a/py/autoevals/oai.py
+++ b/py/autoevals/oai.py
@@ -2,11 +2,13 @@ import asyncio
 import json
 import os
 import sqlite3
+import sys
+import textwrap
 import threading
 import time
 from pathlib import Path
 
-from .util import current_span, prepare_openai_complete
+from .util import current_span
 
 _CACHE_DIR = None
 _CONN = None
@@ -31,6 +33,56 @@ def open_cache():
 
 
 CACHE_LOCK = threading.Lock()
+
+
+def prepare_openai_complete(is_async=False, api_key=None):
+    try:
+        import openai
+    except Exception as e:
+        print(
+            textwrap.dedent(
+                f"""\
+            Unable to import openai: {e}
+
+            Please install it, e.g. with
+
+              pip install 'openai'
+            """
+            ),
+            file=sys.stderr,
+        )
+        raise
+
+    openai_obj = openai
+    is_v1 = False
+    if hasattr(openai, "OpenAI"):
+        # This is the new v1 API
+        is_v1 = True
+        if is_async:
+            openai_obj = openai.AsyncOpenAI(api_key=api_key)
+        else:
+            openai_obj = openai.OpenAI(api_key=api_key)
+
+    try:
+        from braintrust.oai import wrap_openai
+
+        openai_obj = wrap_openai(openai_obj)
+    except ImportError:
+        pass
+
+    complete_fn = None
+    rate_limit_error = None
+    if is_v1:
+        rate_limit_error = openai.RateLimitError
+        complete_fn = openai_obj.chat.completions.create
+    else:
+        rate_limit_error = openai.error.RateLimitError
+        if is_async:
+            complete_fn = openai_obj.ChatCompletion.acreate
+        else:
+            complete_fn = openai_obj.ChatCompletion.create
+
+    return complete_fn, rate_limit_error
 
 
 def post_process_response(resp):

--- a/py/autoevals/util.py
+++ b/py/autoevals/util.py
@@ -1,5 +1,7 @@
 import dataclasses
 import json
+import sys
+import textwrap
 
 
 class SerializableDataClass:
@@ -48,3 +50,48 @@ def traced(*span_args, **span_kwargs):
             return span_args[0]
         else:
             return lambda f: f
+
+def prepare_openai_complete(is_async=False, api_key=None):
+    try:
+        import openai
+    except Exception as e:
+        print(textwrap.dedent(
+            f"""\
+            Unable to import openai. Please install it, e.g. with
+
+              pip install 'openai'
+
+            {e}
+            """
+        ), file=sys.stderr)
+        raise
+
+    openai_obj = openai
+    is_v1 = False
+    if hasattr(openai, "chat") and hasattr(openai.chat, "completions"):
+        # This is the new v1 API
+        is_v1 = True
+        if is_async:
+            openai_obj = openai.AsyncOpenAI(api_key=api_key)
+        else:
+            openai_obj = openai.OpenAI(api_key=api_key)
+
+    try:
+        from braintrust.oai import wrap_openai
+        openai_obj = wrap_openai(openai_obj)
+    except ImportError:
+        pass
+
+    complete_fn = None
+    rate_limit_error = None
+    if is_v1:
+        rate_limit_error = openai.RateLimitError
+        complete_fn = openai_obj.chat.completions.create
+    else:
+        rate_limit_error = openai.error.RateLimitError
+        if is_async:
+            complete_fn = openai_obj.ChatCompletion.acreate
+        else:
+            complete_fn = openai_obj.ChatCompletion.create
+
+    return complete_fn, rate_limit_error

--- a/py/autoevals/util.py
+++ b/py/autoevals/util.py
@@ -51,19 +51,23 @@ def traced(*span_args, **span_kwargs):
         else:
             return lambda f: f
 
+
 def prepare_openai_complete(is_async=False, api_key=None):
     try:
         import openai
     except Exception as e:
-        print(textwrap.dedent(
-            f"""\
-            Unable to import openai. Please install it, e.g. with
+        print(
+            textwrap.dedent(
+                f"""\
+            Unable to import openai: {e}
+
+            Please install it, e.g. with
 
               pip install 'openai'
-
-            {e}
             """
-        ), file=sys.stderr)
+            ),
+            file=sys.stderr,
+        )
         raise
 
     openai_obj = openai
@@ -78,6 +82,7 @@ def prepare_openai_complete(is_async=False, api_key=None):
 
     try:
         from braintrust.oai import wrap_openai
+
         openai_obj = wrap_openai(openai_obj)
     except ImportError:
         pass

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(dir_name, "py", "autoevals", "version.py"), encoding="utf
 with open(os.path.join(dir_name, "README.md"), "r", encoding="utf-8") as f:
     long_description = f.read()
 
-install_requires = ["chevron", "openai==0.28.1", "levenshtein", "pyyaml"]
+install_requires = ["chevron", "levenshtein", "pyyaml"]
 
 extras_require = {
     "dev": [


### PR DESCRIPTION
This change updates autoevals to support both the v0 and v1 versions of OpenAI's python library. To accomplish this, we:

* Remove `openai` as a dependency. This enables autoevals to be included flexibly as a dependency in systems which use either version of openai.
* Wrap the completion method and rate limit exception in a way that works for either SDK version
* Switch to using the wrappers built into the `braintrust` sdk instead of a custom one (except for cached requests...).

Tested using end-to-end scripts with both versions of python.