### PR TITLE
Merge `node`-specific env initialization into `env.ts`.

### DIFF
--- a/js/env.ts
+++ b/js/env.ts
@@ -3,7 +3,10 @@ export interface EnvI {
   OPENAI_BASE_URL?: string;
 }
 
-export const Env: EnvI = {
-  OPENAI_API_KEY: undefined,
-  OPENAI_BASE_URL: undefined,
-};
+export const Env: EnvI =
+  typeof process === "undefined"
+    ? {}
+    : {
+        OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+        OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+      };

--- a/js/node.ts
+++ b/js/node.ts
@@ -1,5 +1,0 @@
-import { Env } from "./env.js";
-Env.OPENAI_API_KEY = process.env.OPENAI_API_KEY;
-Env.OPENAI_BASE_URL = process.env.OPENAI_BASE_URL;
-
-export * from "./index.js";


### PR DESCRIPTION
Currently we don't seem to be running the `node.ts` initialization anywhere, so the env vars are never populated. This makes it impossible to use env vars to override `OPENAI_API_KEY` or `OPENAI_BASE_URL`.

Since the logic is so simple, we implement it directly in `env.ts`.