### PR TITLE
README fix + use enums to improve classification accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,10 @@ Issue Description: {{input}}
 output_scores = {"1": 1, "2": 0}
 
 evaluator = LLMClassifier(
-    prompt_prefix,
-    output_scores,
-    use_cot=False,
+    name="TitleQuality",
+    prompt_template=prompt_prefix,
+    choice_scores=output_scores,
+    use_cot=True,
 )
 
 # Evaluate an example LLM completion
@@ -244,9 +245,10 @@ Issue Description: {{input}}
   const choiceScores = { 1: 1, 2: 0 };
 
   const evaluator = LLMClassifierFromTemplate({
+    name: "TitleQuality",
     promptTemplate,
     choiceScores,
-    useCoT: false,
+    useCoT: true,
   });
 
   const input = `As suggested by Nicolo, we should standardize the error responses coming from GoTrue, postgres, and realtime (and any other/future APIs) so that it's better DX when writing a client,

--- a/js/llm.ts
+++ b/js/llm.ts
@@ -48,12 +48,23 @@ const COT_RESPONSE_SCHEMA = {
   type: "object",
 };
 
-export function buildClassificationFunctions(useCoT: boolean) {
+export function buildClassificationFunctions(
+  useCoT: boolean,
+  choiceStrings: string[]
+) {
+  const params = useCoT ? COT_RESPONSE_SCHEMA : PLAIN_RESPONSE_SCHEMA;
+  const enumParams = {
+    ...params,
+    properties: {
+      ...params.properties,
+      choice: { ...params.properties.choice, enum: choiceStrings },
+    },
+  };
   return [
     {
       name: "select_choice",
       description: "Call this function to select a choice.",
-      parameters: useCoT ? COT_RESPONSE_SCHEMA : PLAIN_RESPONSE_SCHEMA,
+      parameters: enumParams,
     },
   ];
 }
@@ -230,7 +241,10 @@ export function LLMClassifierFromTemplate<RenderArgs>({
       name,
       messages,
       choiceScores,
-      classificationFunctions: buildClassificationFunctions(useCoT),
+      classificationFunctions: buildClassificationFunctions(
+        useCoT,
+        choiceStrings
+      ),
       model,
       maxTokens,
       temperature,

--- a/node/llm.test.ts
+++ b/node/llm.test.ts
@@ -54,7 +54,7 @@ Nicolo also dropped this as a reference: http://spec.openapis.org/oas/v3.0.3#ope
     model: "gpt-3.5-turbo",
     parseScoreFn: parseBestTitle,
     choiceScores: { "1": 1, "2": 0 },
-    classificationFunctions: buildClassificationFunctions(true),
+    classificationFunctions: buildClassificationFunctions(true, ["1", "2"]),
     page_content,
     maxTokens: 500,
     cache,

--- a/py/autoevals/llm.py
+++ b/py/autoevals/llm.py
@@ -55,13 +55,17 @@ COT_RESPONSE_SCHEMA = {
 }
 
 
-def build_classification_functions(useCoT):
+def build_classification_functions(useCoT, choice_strings):
+    params = COT_RESPONSE_SCHEMA if useCoT else PLAIN_RESPONSE_SCHEMA
+    enum_params = {
+        **params,
+        "properties": {
+            **params["properties"],
+            "choice": {**params["properties"]["choice"], "enum": choice_strings},
+        },
+    }
     return [
-        {
-            "name": "select_choice",
-            "description": "Call this function to select a choice.",
-            "parameters": COT_RESPONSE_SCHEMA if useCoT else PLAIN_RESPONSE_SCHEMA,
-        }
+        {"name": "select_choice", "description": "Call this function to select a choice.", "parameters": enum_params}
     ]
 
 
@@ -210,7 +214,7 @@ class LLMClassifier(OpenAILLMClassifier):
             messages,
             model,
             choice_scores,
-            classification_functions=build_classification_functions(use_cot),
+            classification_functions=build_classification_functions(use_cot, choice_strings),
             max_tokens=max_tokens,
             temperature=temperature,
             engine=engine,

--- a/py/autoevals/test_llm.py
+++ b/py/autoevals/test_llm.py
@@ -41,7 +41,7 @@ the select_choice function with "1" or "2".""",
         ],
         model="gpt-3.5-turbo",
         choice_scores={"1": 1, "2": 0},
-        classification_functions=build_classification_functions(useCoT=True),
+        classification_functions=build_classification_functions(useCoT=True, choice_strings=["1", "2"]),
         max_tokens=500,
     )
 


### PR DESCRIPTION
* Fix syntax for custom prompts in README
* Use `enum` in json schema to improve accuracy