### PR TITLE
Don't swallow errors into scores.

### DIFF
--- a/py/autoevals/llm.py
+++ b/py/autoevals/llm.py
@@ -150,9 +150,7 @@ class OpenAILLMClassifier(Scorer):
             raise ValueError("Empty response from OpenAI")
 
     async def _run_eval_async(self, output, expected, **kwargs):
-        return self._postprocess_response(
-            await arun_cached_request(**self._request_args(output, expected, **kwargs))
-        )
+        return self._postprocess_response(await arun_cached_request(**self._request_args(output, expected, **kwargs)))
 
     def _run_eval_sync(self, output, expected, **kwargs):
         return self._postprocess_response(run_cached_request(**self._request_args(output, expected, **kwargs)))

--- a/py/autoevals/llm.py
+++ b/py/autoevals/llm.py
@@ -108,20 +108,14 @@ class OpenAILLMClassifier(Scorer):
 
     def _process_response(self, resp):
         metadata = {}
-        try:
-            args = json.loads(resp["function_call"]["arguments"])
-            if "reasons" in args:
-                metadata["rationale"] = "\n".join(args["reasons"])
-            if "function_call" not in resp:
-                raise ValueError("No function call found in response")
-            metadata["choice"] = args["choice"].strip()
-            score = self.choice_scores[metadata["choice"]]
-            error = None
-        except Exception as e:
-            score = 0
-            error = e
-
-        return Score(name=self.name, score=score, metadata=metadata, error=error)
+        args = json.loads(resp["function_call"]["arguments"])
+        if "reasons" in args:
+            metadata["rationale"] = "\n".join(args["reasons"])
+        if "function_call" not in resp:
+            raise ValueError("No function call found in response")
+        metadata["choice"] = args["choice"].strip()
+        score = self.choice_scores[metadata["choice"]]
+        return Score(name=self.name, score=score, metadata=metadata)
 
     def _render_messages(self, **kwargs):
         kwargs.update(self.render_args)
@@ -156,18 +150,12 @@ class OpenAILLMClassifier(Scorer):
             raise ValueError("Empty response from OpenAI")
 
     async def _run_eval_async(self, output, expected, **kwargs):
-        try:
-            return self._postprocess_response(
-                await arun_cached_request(**self._request_args(output, expected, **kwargs))
-            )
-        except Exception as e:
-            return Score(name=self.name, score=0, error=e)
+        return self._postprocess_response(
+            await arun_cached_request(**self._request_args(output, expected, **kwargs))
+        )
 
     def _run_eval_sync(self, output, expected, **kwargs):
-        try:
-            return self._postprocess_response(run_cached_request(**self._request_args(output, expected, **kwargs)))
-        except Exception as e:
-            return Score(name=self.name, score=0, error=e)
+        return self._postprocess_response(run_cached_request(**self._request_args(output, expected, **kwargs)))
 
 
 @dataclass


### PR DESCRIPTION
It makes debugging more difficult, as the user has to deep-dive into eval results to find errors. Now that the `Eval` framework captures and reports errors, it should be fine to bubble them up.