### PR TITLE
Add Valid JSON as a scorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ npx braintrust run example.eval.js
 - Summarization
 - SQL
 - Translation
-- [ ] Fine-tuned binary classifiers
+- Fine-tuned binary classifiers
 
 ### RAGAS
 
@@ -174,24 +174,25 @@ npx braintrust run example.eval.js
 ### Composite
 
 - Semantic list contains
+- JSON validity
 
 ### Embeddings
 
 - Embedding similarity
-- [ ] BERTScore
+- BERTScore
 
 ### Heuristic
 
 - Levenshtein distance
 - Numeric difference
 - JSON diff
-- [ ] Jaccard distance
+- Jaccard distance
 
 ### Statistical
 
-- [ ] BLEU
-- [ ] ROUGE
-- [ ] METEOR
+- BLEU
+- ROUGE
+- METEOR
 
 ## Custom Evaluation Prompts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@braintrust/core": "^0.0.8",
+        "ajv": "^8.13.0",
         "compute-cosine-similarity": "^1.1.0",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
@@ -1910,6 +1911,21 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2744,6 +2760,11 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -4011,6 +4032,11 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4773,7 +4799,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4837,6 +4862,14 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6031,6 +6064,14 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@braintrust/core": "^0.0.8",
+    "ajv": "^8.13.0",
     "compute-cosine-similarity": "^1.1.0",
     "js-levenshtein": "^1.1.6",
     "js-yaml": "^4.1.0",

--- a/py/autoevals/test_json.py
+++ b/py/autoevals/test_json.py
@@ -1,6 +1,6 @@
 from pytest import approx
 
-from autoevals.json import JSONDiff
+from autoevals.json import JSONDiff, ValidJSON
 
 
 def test_string_as_json():
@@ -45,3 +45,56 @@ def test_json():
     for a, b, expected in cases:
         print(f"[{a}]", f"[{b}]", expected, evaluator(a, b))
         assert evaluator(a, b).score == approx(expected, 1e-4)
+
+
+def test_valid_json():
+    cases = [
+        ("1", 0, None),
+        ('{ "a": 1, "b": "hello" }', 1, None),
+        ('[{ "a": 1 }]', 1, None),
+        ('[{ "a": 1 }', 0, None),
+        ('{ "mapping": { "a": "foo", "b": "bar" }, "extra": 4 }', 1, None),
+        ('{ mapping: { "a": "foo", "b": "bar" }, "extra": 4 }', 0, None),
+        (
+            '{ "a": "1" }',
+            1,
+            {
+                "type": "object",
+                "properties": {"a": {"type": "string"}},
+                "required": ["a"],
+            },
+        ),
+        (
+            '{"a": "1", "b": "1"}',
+            0,
+            {
+                "type": "object",
+                "properties": {
+                    "a": {"type": "string"},
+                    "b": {"type": "number"},
+                },
+                "required": ["a"],
+            },
+        ),
+        (
+            '[{"a": "1"}, {"a": "1", "b": 22}]',
+            1,
+            {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "string"},
+                        "b": {"type": "number"},
+                    },
+                    "required": ["a"],
+                },
+                "uniqueItems": True,
+            },
+        ),
+    ]
+
+    evaluator = ValidJSON()
+    for output, expected, schema in cases:
+        print(f"[{output}]", expected)
+        assert evaluator(output, schema).score == expected

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(dir_name, "py", "autoevals", "version.py"), encoding="utf
 with open(os.path.join(dir_name, "README.md"), "r", encoding="utf-8") as f:
     long_description = f.read()
 
-install_requires = ["chevron", "levenshtein", "pyyaml", "braintrust_core"]
+install_requires = ["chevron", "levenshtein", "pyyaml", "braintrust_core", "jsonschema"]
 
 extras_require = {
     "dev": [


### PR DESCRIPTION
Adds a new scorer that returns 1 when the response represents a valid JSON response, and otherwise returns 0. Optionally, the user can pass in a JSON schema definition, so the response must be valid JSON and conform to the schema definition in order to pass the check.