### PR TITLE
Pin zod to 3.22.4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "linear-sum-assignment": "^1.0.7",
     "mustache": "^4.2.0",
     "openai": "4.47.1",
-    "zod": "^3.22.4",
+    "zod": "3.22.4",
     "zod-to-json-schema": "^3.22.5"
   }
 }


### PR DESCRIPTION
Aligns with internal changes. We were ending up with multiple versions of zod floating around across projects which made our builds get confused.