### PR TITLE
Update links for npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+Release notes can be found [here](https://www.braintrust.dev/docs/reference/release-notes).

--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "autoevals",
   "version": "0.0.0",
   "description": "Universal library for evaluating AI models",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/braintrustdata/autoevals.git"
+  },
+  "homepage": "https://www.braintrust.dev/docs",
   "main": "./jsdist/index.js",
   "module": "./jsdist/index.mjs",
   "types": "./jsdist/index.d.ts",


### PR DESCRIPTION
The update to the package.json file allows the npm package to link to the repository and the homepage from the main npm page https://www.npmjs.com/package/autoevals