### PR TITLE
Add customizable embedding model to `AnswerRelevancy` metric

### DIFF
--- a/js/ragas.ts
+++ b/js/ragas.ts
@@ -777,7 +777,7 @@ export const AnswerCorrectness: ScorerWithPartial<
     factualityWeight?: number;
     answerSimilarityWeight?: number;
     answerSimilarity?: Scorer<string, {}>;
-  } & RagasEmbeddingModelArgs
+  }
 > = makePartial(async (args) => {
   const { chatArgs, client, ...inputs } = parseArgs(args);
 

--- a/js/ragas.ts
+++ b/js/ragas.ts
@@ -688,31 +688,28 @@ export const AnswerRelevancy: ScorerWithPartial<
 /**
  * Scores the semantic similarity between the generated answer and ground truth.
  */
-export const AnswerSimilarity: ScorerWithPartial<
-  string,
-  RagasArgs & RagasEmbeddingModelArgs
-> = makePartial(async (args) => {
-  const { ...inputs } = parseArgs(args);
+export const AnswerSimilarity: ScorerWithPartial<string, RagasArgs> =
+  makePartial(async (args) => {
+    const { ...inputs } = parseArgs(args);
 
-  const { output, expected } = checkRequired(
-    { output: inputs.output, expected: inputs.expected },
-    "AnswerSimilarity",
-  );
+    const { output, expected } = checkRequired(
+      { output: inputs.output, expected: inputs.expected },
+      "AnswerSimilarity",
+    );
 
-  const { score, error } = await EmbeddingSimilarity({
-    ...extractOpenAIArgs(args),
-    output,
-    expected,
-    expectedMin: 0,
-    model: args.embeddingModel,
-  });
+    const { score, error } = await EmbeddingSimilarity({
+      ...extractOpenAIArgs(args),
+      output,
+      expected,
+      expectedMin: 0,
+    });
 
-  return {
-    name: "AnswerSimilarity",
-    score,
-    error,
-  };
-}, "AnswerSimilarity");
+    return {
+      name: "AnswerSimilarity",
+      score,
+      error,
+    };
+  }, "AnswerSimilarity");
 
 const CORRECTNESS_PROMPT = `Given a ground truth and an answer, analyze each statement in the answer and classify them in one of the following categories:
 

--- a/js/ragas.ts
+++ b/js/ragas.ts
@@ -603,6 +603,11 @@ export const AnswerRelevancy: ScorerWithPartial<
   string,
   RagasArgs & {
     strictness?: number;
+    /**
+      @default
+      If not provided, the default model of {@link EmbeddingSimilarity} is
+     */
+    embeddingModel?: string;
   }
 > = makePartial(async (args) => {
   const { chatArgs, client, ...inputs } = parseArgs(args);
@@ -656,6 +661,7 @@ export const AnswerRelevancy: ScorerWithPartial<
         ...extractOpenAIArgs(args),
         output: question,
         expected: input,
+        model: args.embeddingModel,
       });
       return { question, score };
     }),

--- a/js/ragas.ts
+++ b/js/ragas.ts
@@ -605,7 +605,7 @@ export const AnswerRelevancy: ScorerWithPartial<
     strictness?: number;
     /**
       @default
-      If not provided, the default model of {@link EmbeddingSimilarity} is
+      If not provided, the default model of {@link EmbeddingSimilarity} is used.
      */
     embeddingModel?: string;
   }

--- a/py/autoevals/ragas.py
+++ b/py/autoevals/ragas.py
@@ -19,6 +19,7 @@ def check_required(name, **kwargs):
 
 
 DEFAULT_RAGAS_MODEL = "gpt-3.5-turbo-16k"
+DEFAULT_RAGAS_EMBEDDING_MODEL = "text-embedding-ada-002"
 
 ENTITY_PROMPT = """Given a text, extract unique entities without repetition. Ensure you consider different forms or mentions of the same entity as a single entity.
 
@@ -830,12 +831,20 @@ class AnswerRelevancy(OpenAILLMScorer):
     Answers with incomplete, redundant or unnecessary information are penalized.
     """
 
-    def __init__(self, model=DEFAULT_RAGAS_MODEL, strictness=3, temperature=0.5, **kwargs):
+    def __init__(
+        self,
+        model=DEFAULT_RAGAS_MODEL,
+        strictness=3,
+        temperature=0.5,
+        embedding_model=DEFAULT_RAGAS_EMBEDDING_MODEL,
+        **kwargs,
+    ):
         super().__init__(temperature=temperature, **kwargs)
 
         self.model = model
         self.strictness = strictness
         self.temperature = temperature
+        self.embedding_model = embedding_model
 
     def _postprocess(self, questions, similarity):
         score = (
@@ -866,7 +875,7 @@ class AnswerRelevancy(OpenAILLMScorer):
         )
         similarity = await asyncio.gather(
             *[
-                EmbeddingSimilarity().eval_async(output=q["question"], expected=input, model=self.model)
+                EmbeddingSimilarity().eval_async(output=q["question"], expected=input, model=self.embedding_model)
                 for q in questions
             ]
         )
@@ -894,7 +903,7 @@ class AnswerSimilarity(OpenAILLMScorer):
     Measures the similarity between the generated answer and the expected answer.
     """
 
-    def __init__(self, pairwise_scorer=None, model=DEFAULT_RAGAS_MODEL, **kwargs):
+    def __init__(self, pairwise_scorer=None, model=DEFAULT_RAGAS_EMBEDDING_MODEL, **kwargs):
         super().__init__(**kwargs)
 
         self.model = model


### PR DESCRIPTION
Currently, the embedding model used by the Ragas `AnswerRelevancy` metric isn't configurable. It defaults to the default of `EmbeddingSimilarity`, which is currently `"text-embedding-ada-002"`. 

This PR makes the model configurable.

This is useful for all users who don't want to use the model "text-embedding-ada-002" or for Azure OpenAI users who use that model but give it a different name (which is configurable in the Azure OpenAI service)