### PR TITLE
Ensure EmbeddingSimilarity scores do not exceed 1

### DIFF
--- a/js/ragas.test.ts
+++ b/js/ragas.test.ts
@@ -79,6 +79,7 @@ test("Ragas end-to-end test", async () => {
 
     if (score === 1) {
       expect(actualScore.score).toBeCloseTo(score, 4);
+      expect(actualScore.score).toBeLessThanOrEqual(1);
     }
   }
 }, 600000);

--- a/js/string.ts
+++ b/js/string.ts
@@ -87,5 +87,5 @@ export const EmbeddingSimilarity: ScorerWithPartial<
 }, "EmbeddingSimilarity");
 
 function scaleScore(score: number, expectedMin: number): number {
-  return Math.max((score - expectedMin) / (1 - expectedMin), 0);
+  return Math.min(Math.max((score - expectedMin) / (1 - expectedMin), 0), 1);
 }


### PR DESCRIPTION
It turns out that when the `output` and `expected` are *exactly* the same, the cosine similarity util that we are using can return numbers slightly greater than 1.

I verified this by console.logging in the test suite. The test suite was happily calling `1.0000000009` close enough to `1`. 

![image](https://github.com/user-attachments/assets/6f0c290b-5e49-4aa0-91e4-4f13c9cb10a8)

So, I modified the `scaleScore` function used to massage the value returned by `cossim` to not return anything larger than 1. 

I also updated the test to ensure we don't regress here.