### PR TITLE
Allow passing a custom OpenAI client to `OpenAIScorer` and subclasses.

### DIFF
--- a/py/autoevals/llm.py
+++ b/py/autoevals/llm.py
@@ -79,12 +79,15 @@ class OpenAIScorer(ScorerWithPartial):
         self,
         api_key=None,
         base_url=None,
+        client=None,
     ):
         self.extra_args = {}
         if api_key:
             self.extra_args["api_key"] = api_key
         if base_url:
             self.extra_args["base_url"] = base_url
+        if client:
+            self.extra_args["client"] = client
 
 
 class OpenAILLMScorer(OpenAIScorer):
@@ -93,10 +96,12 @@ class OpenAILLMScorer(OpenAIScorer):
         temperature=None,
         api_key=None,
         base_url=None,
+        client=None,
     ):
         super().__init__(
             api_key=api_key,
             base_url=base_url,
+            client=client,
         )
         self.extra_args["temperature"] = temperature or 0
 
@@ -115,10 +120,12 @@ class OpenAILLMClassifier(OpenAILLMScorer):
         engine=None,
         api_key=None,
         base_url=None,
+        client=None,
     ):
         super().__init__(
             api_key=api_key,
             base_url=base_url,
+            client=client,
         )
 
         self.name = name
@@ -233,6 +240,7 @@ class LLMClassifier(OpenAILLMClassifier):
         engine=None,
         api_key=None,
         base_url=None,
+        client=None,
         **extra_render_args,
     ):
         choice_strings = list(choice_scores.keys())
@@ -256,6 +264,7 @@ class LLMClassifier(OpenAILLMClassifier):
             engine=engine,
             api_key=api_key,
             base_url=base_url,
+            client=client,
             render_args={"__choices": choice_strings, **extra_render_args},
         )
 
@@ -274,7 +283,15 @@ class LLMClassifier(OpenAILLMClassifier):
 
 class SpecFileClassifier(LLMClassifier):
     def __new__(
-        cls, model=None, engine=None, use_cot=None, max_tokens=None, temperature=None, api_key=None, base_url=None
+        cls,
+        model=None,
+        engine=None,
+        use_cot=None,
+        max_tokens=None,
+        temperature=None,
+        api_key=None,
+        base_url=None,
+        client=None,
     ):
         kwargs = {}
         if model is not None:
@@ -291,6 +308,8 @@ class SpecFileClassifier(LLMClassifier):
             kwargs["api_key"] = api_key
         if base_url is not None:
             kwargs["base_url"] = base_url
+        if client is not None:
+            kwargs["client"] = client
 
         # convert FooBar to foo_bar
         cls_name = cls.__name__

--- a/py/autoevals/oai.py
+++ b/py/autoevals/oai.py
@@ -47,9 +47,9 @@ def prepare_openai(is_async=False, api_key=None, base_url=None, client=None):
     is_v1 = False
 
     if client is not None:
-        # v1+ AzureOpenAI and OpenAI clients have a `_version` attribute
-        is_v1 = getattr(client, "_version", "0") >= "1"
         openai_obj = client
+        # Custom clients require v1+ (non-legacy) API
+        is_v1 = True
     elif hasattr(openai, "OpenAI"):
         # This is the new v1 API
         is_v1 = True


### PR DESCRIPTION
This PR adds an optional `client=` kwarg to the `OpenAIScorer` and its subclasses (e.g., `LLMClassifier`). This allows the end user to a custom configured client, a client with an OpenAI-compatible interface (including an `AzureOpenAI` client), or otherwise exhibit greater control over the client configuration for Braintrust evals. Currently, the client is still wrapped with `wrap_openai` and we assume that the client follows the OpenAI v1 API specification.

Usage example:

```python3
from openai import AzureOpenAI

azure_client = AzureOpenAI()

# Compare a model response vs. some expected response (e.g., a vanilla ChatGPT reply), using an Azure OpenAI deployment
elo_scorer = LLMClassifier(
    name="Versus (GPT-4o)",
    prompt_template=(
        "Evaluate two responses and indicate which provides a superior answer to the question "
        "or whether they are a equally good/a tie.\n\n"
        "Question: {{input}}\n"
        "Response A: {{output}}\n"
        "Response B: {{expected}}\n\n"
        "Your output should be one of A, B, or Tie."
    ),
    choice_scores={"A": 1, "B": 0, "Tie": 0.5},
    use_cot=True,
    client=azure_client,
)
```