### PR TITLE
Remove pytest-watch to unbreak builds with setuptools v78.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ extras_require = {
         "openai",  # used for testing
         "pre-commit",
         "pytest",
-        "pytest-watch",
         "respx",
         "twine",
     ],


### PR DESCRIPTION
https://github.com/joeyespo/pytest-watch/issues/134
ref braintrustdata/braintrust-sdk#600

Removing this package to unblock builds, we can investigate using pytest-watcher or some maintained replacement for pytest-watch later