### PR TITLE
Add caret to openai dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "js-yaml": "^4.1.0",
     "linear-sum-assignment": "^1.0.7",
     "mustache": "^4.2.0",
-    "openai": "4.47.1",
+    "openai": "^4.47.1",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.22.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
       openai:
-        specifier: 4.47.1
+        specifier: ^4.47.1
         version: 4.47.1
       zod:
         specifier: ^3.22.4


### PR DESCRIPTION
Not having the caret makes using a more modern but semver compatible openai dependency much more difficult
