### PR TITLE
Use embedding_model parameter in AnswerRelevancy sync runner instead of model

### DIFF
--- a/py/autoevals/ragas.py
+++ b/py/autoevals/ragas.py
@@ -1176,8 +1176,8 @@ class AnswerRelevancy(OpenAILLMScorer):
         )
         similarity = await asyncio.gather(
             *[
-                EmbeddingSimilarity(client=self.client).eval_async(
-                    output=q["question"], expected=input, model=self.embedding_model
+                EmbeddingSimilarity(client=self.client, model=self.embedding_model).eval_async(
+                    output=q["question"], expected=input
                 )
                 for q in questions
             ]
@@ -1196,7 +1196,7 @@ class AnswerRelevancy(OpenAILLMScorer):
             for _ in range(self.strictness)
         ]
         similarity = [
-            EmbeddingSimilarity(client=self.client).eval(output=q["question"], expected=input, model=self.embedding_model)
+            EmbeddingSimilarity(client=self.client, model=self.embedding_model).eval(output=q["question"], expected=input)
             for q in questions
         ]
 


### PR DESCRIPTION
The AnswerRelevancy scorer allows to pass an `embedding_model` parameter, which is used in the `EmbeddingSimilarity` call of the  async runner, but not in the synchronous version, leading to wrong model usage when using the scorer synchronously.

Issue #166 

Edit: Moved model parameter to `EmbeddingSimilarity`init instead of eval call.