### PR TITLE
Fix MDX parsing by escaping curly braces in JSDoc comment

### DIFF
--- a/js/llm.ts
+++ b/js/llm.ts
@@ -45,7 +45,7 @@ export const THREAD_VARIABLE_PATTERN = new RegExp(
 
 /**
  * Check if a template string might use thread-related template variables.
- * This is a heuristic - looks for variable names after {{ or {% syntax.
+ * This is a heuristic - looks for variable names after `{{` or `{%` syntax.
  */
 export function templateUsesThreadVariables(template: string): boolean {
   return THREAD_VARIABLE_PATTERN.test(template);


### PR DESCRIPTION
## Summary

Escapes `{{` and `{%` in the JSDoc comment for `templateUsesThreadVariables` to prevent them from being interpreted as JSX expressions when generating MDX documentation.

## Problem

The TypeScript reference docs (versions 0.0.131 and 0.0.132) were failing to parse with the error:
```
Unexpected end of file in expression, expected a corresponding closing brace for `{`
```

This was caused by unescaped curly braces in the JSDoc comment at line 48 of `js/llm.ts`.

## Solution

Wrapped the template syntax examples in backticks to make them inline code, which prevents the MDX parser from treating them as JSX expressions.

## Testing

After this fix is merged and the submodule is updated in the braintrust repo, the docs will need to be regenerated using:
```bash
make docs-libraries
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)