### PR TITLE
Add pnpm enforcement and config

### DIFF
--- a/.github/workflows/enforce-pnpm.yml
+++ b/.github/workflows/enforce-pnpm.yml
@@ -1,0 +1,17 @@
+name: Enforce pnpm
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  reject-npm-lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Reject npm lockfiles
+        run: |
+          if git ls-files | grep -E '(^|/)package-lock\.json$'; then
+            echo "Remove package-lock.json and use pnpm."
+            exit 1
+          fi

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -23,10 +23,23 @@
     "jsdist/**/*"
   ],
   "scripts": {
+    "preinstall": "node -e \"const userAgent = process.env.npm_config_user_agent || ''; if (process.env.INIT_CWD === process.cwd() && !userAgent.includes('pnpm/')) { console.error('Use pnpm in this repo.'); process.exit(1); }\"",
     "build": "tsup",
     "watch": "tsup --watch",
     "docs": "npx typedoc --options typedoc.json js/index.ts",
     "test": "vitest"
+  },
+  "engines": {
+    "pnpm": ">=10.27.0",
+    "npm": "please-use-pnpm",
+    "yarn": "please-use-pnpm"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": ">=10.27.0",
+      "onFail": "error"
+    }
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Introduces a GitHub Actions workflow to reject pull requests containing `package-lock.json`.
Adds an `.npmrc` file to enforce strict engine versions. Modifies `package.json` to include a `preinstall` script that checks for `pnpm` usage and sets up `devEngines` to specify the required package manager.