### PR TITLE
chore: Publish python via trusted publishing and unify release process

### DIFF
--- a/.github/scripts/check_version_sync.py
+++ b/.github/scripts/check_version_sync.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_JSON = ROOT / "package.json"
+PY_VERSION = ROOT / "py" / "autoevals" / "version.py"
+
+package_version = json.loads(PACKAGE_JSON.read_text(encoding="utf-8"))["version"]
+match = re.search(
+    r'^VERSION\s*=\s*["\']([^"\']+)["\']\s*$',
+    PY_VERSION.read_text(encoding="utf-8"),
+    re.MULTILINE,
+)
+
+if not match:
+    print(f"Could not parse VERSION from {PY_VERSION}", file=sys.stderr)
+    sys.exit(1)
+
+python_version = match.group(1)
+
+if package_version != python_version:
+    print(
+        "Version mismatch detected:\n"
+        f"- package.json: {package_version}\n"
+        f"- py/autoevals/version.py: {python_version}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(f"Versions are in sync: {package_version}")

--- a/.github/workflows/publish-py.yaml
+++ b/.github/workflows/publish-py.yaml
@@ -1,7 +1,7 @@
-name: publish-js
+name: publish-py
 
 concurrency:
-  group: publish-js-${{ inputs.release_type }}-${{ inputs.branch }}
+  group: publish-py-${{ inputs.release_type }}-${{ inputs.branch }}
   cancel-in-progress: false
 
 on:
@@ -41,12 +41,15 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ inputs.branch }}
+
       - name: Check version sync
         run: python3 .github/scripts/check_version_sync.py
-      - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+
+      - name: Set up Python
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
         with:
-          node-version: 22
+          python-version: "3.12"
+
       - name: Determine release metadata
         id: release_metadata
         env:
@@ -56,7 +59,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          CURRENT_VERSION=$(python -c 'from pathlib import Path; ns = {}; exec(Path("py/autoevals/version.py").read_text(encoding="utf-8"), ns); print(ns["VERSION"])')
           RELEASE_COMMIT=$(git rev-parse HEAD)
 
           if [[ -z "${PRERELEASE_SUFFIX}" ]]; then
@@ -68,7 +71,7 @@ jobs:
           echo "commit=${RELEASE_COMMIT}" >> "$GITHUB_OUTPUT"
 
           if [[ "$RELEASE_TYPE" == "stable" ]]; then
-            RELEASE_TAG="js-${CURRENT_VERSION}"
+            RELEASE_TAG="py-${CURRENT_VERSION}"
 
             if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
               echo "Tag ${RELEASE_TAG} already exists on origin" >&2
@@ -78,7 +81,7 @@ jobs:
             echo "version=${CURRENT_VERSION}" >> "$GITHUB_OUTPUT"
             echo "release_tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
           else
-            VERSION="${CURRENT_VERSION}-rc.${PRERELEASE_SUFFIX}"
+            VERSION="${CURRENT_VERSION}rc${PRERELEASE_SUFFIX}"
 
             echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "release_tag=" >> "$GITHUB_OUTPUT"
@@ -90,7 +93,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write
-      id-token: write
+      id-token: write # Required for PyPI trusted publishing
     env:
       PACKAGE_NAME: autoevals
       VERSION: ${{ needs.prepare-release.outputs.version }}
@@ -107,50 +110,76 @@ jobs:
       - name: Check version sync
         run: python3 .github/scripts/check_version_sync.py
 
-      - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - name: Set up Python
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
         with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
+          python-version: "3.12"
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
-        with:
-          version: 10.26.2
-
-      - name: Check npm version availability
+      - name: Check PyPI version availability
         run: |
           set -euo pipefail
 
-          if npm view "${PACKAGE_NAME}@${VERSION}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
-            echo "${PACKAGE_NAME}@${VERSION} already exists on npm" >&2
-            exit 1
-          fi
+          python - <<'PY'
+          import os
+          import sys
+          import urllib.error
+          import urllib.request
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          package = os.environ["PACKAGE_NAME"]
+          version = os.environ["VERSION"]
+          url = f"https://pypi.org/pypi/{package}/{version}/json"
+
+          try:
+              urllib.request.urlopen(url)
+          except urllib.error.HTTPError as exc:
+              if exc.code == 404:
+                  raise SystemExit(0)
+              raise
+          except urllib.error.URLError as exc:
+              print(f"Failed to query PyPI: {exc}", file=sys.stderr)
+              raise
+          else:
+              print(f"{package}=={version} already exists on PyPI", file=sys.stderr)
+              raise SystemExit(1)
+          PY
+
+      - name: Install build dependencies
+        run: python -m pip install --upgrade pip build twine
 
       - name: Prepare prerelease package metadata
         if: ${{ env.RELEASE_TYPE == 'prerelease' }}
         run: |
           set -euo pipefail
 
-          node -e '
-            const fs = require("fs");
-            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
-            pkg.version = process.env.VERSION;
-            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
-          '
+          python - <<'PY'
+          import os
+          import re
+          from pathlib import Path
+
+          path = Path("py/autoevals/version.py")
+          text = path.read_text(encoding="utf-8")
+          new_text, count = re.subn(
+              r'^VERSION\s*=\s*["\'][^"\']+["\']\s*$',
+              f'VERSION = "{os.environ["VERSION"]}"',
+              text,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          if count != 1:
+              raise SystemExit("Could not update py/autoevals/version.py for prerelease publish")
+          path.write_text(new_text + ("" if new_text.endswith("\n") else "\n"), encoding="utf-8")
+          PY
 
       - name: Build package
-        run: pnpm run build
+        run: python -m build
 
-      - name: Publish stable release to npm
-        if: ${{ env.RELEASE_TYPE == 'stable' }}
-        run: npm publish --provenance --access public
+      - name: Verify package metadata
+        run: python -m twine check dist/*
 
-      - name: Publish prerelease to npm
-        if: ${{ env.RELEASE_TYPE == 'prerelease' }}
-        run: npm publish --tag rc --provenance --access public
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+        with:
+          packages-dir: dist/
 
       - name: Create and push stable release tag
         if: ${{ env.RELEASE_TYPE == 'stable' }}
@@ -174,7 +203,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: process.env.RELEASE_TAG,
-              name: `autoevals JavaScript v${process.env.VERSION}`,
+              name: `autoevals Python v${process.env.VERSION}`,
               draft: false,
               prerelease: false,
               generate_release_notes: true,
@@ -185,16 +214,15 @@ jobs:
           set -euo pipefail
 
           {
-            echo "## npm publish complete"
+            echo "## PyPI publish complete"
             echo
             echo "- Package: \`${PACKAGE_NAME}\`"
             echo "- Version: \`${VERSION}\`"
             echo "- Release type: \`${RELEASE_TYPE}\`"
             if [ "${RELEASE_TYPE}" = "prerelease" ]; then
-              echo "- npm tag: \`rc\`"
-              echo "- Install: \`npm install ${PACKAGE_NAME}@rc\`"
+              echo "- Install: \`pip install --pre ${PACKAGE_NAME}\`"
             else
               echo "- Git tag: \`${RELEASE_TAG}\`"
-              echo "- Install: \`npm install ${PACKAGE_NAME}\`"
+              echo "- Install: \`pip install ${PACKAGE_NAME}\`"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,66 @@
+name: publish
+
+concurrency:
+  group: publish-${{ inputs.release_type }}-${{ inputs.branch }}
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: Release type
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - prerelease
+      branch:
+        description: Branch to publish from
+        required: true
+        default: main
+        type: string
+
+jobs:
+  dispatch-package-publishes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch JS and Python publish workflows
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          RELEASE_TYPE: ${{ inputs.release_type }}
+          TARGET_BRANCH: ${{ inputs.branch }}
+          PRERELEASE_SUFFIX: ${{ github.run_number }}
+          WORKFLOW_REF: main
+        with:
+          script: |
+            const workflows = ["publish-js.yaml", "publish-py.yaml"];
+            for (const workflow_id of workflows) {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id,
+                ref: process.env.WORKFLOW_REF,
+                inputs: {
+                  release_type: process.env.RELEASE_TYPE,
+                  branch: process.env.TARGET_BRANCH,
+                  prerelease_suffix: process.env.PRERELEASE_SUFFIX,
+                },
+              });
+            }
+
+      - name: Summarize dispatch
+        run: |
+          {
+            echo "## Package publishes queued"
+            echo
+            echo "- Workflows: \`publish-js.yaml\`, \`publish-py.yaml\`"
+            echo "- Release type: \`${{ inputs.release_type }}\`"
+            echo "- Branch: \`${{ inputs.branch }}\`"
+            if [ "${{ inputs.release_type }}" = "prerelease" ]; then
+              echo "- Shared prerelease suffix: \`${{ github.run_number }}\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/version-sync.yaml
+++ b/.github/workflows/version-sync.yaml
@@ -1,0 +1,15 @@
+name: version-sync
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Check JS and Python package versions match
+        run: python3 .github/scripts/check_version_sync.py

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,6 +1,64 @@
 # Publishing
 
-This repository contains both JavaScript and Python packages. The JavaScript package (`autoevals`) is published to npm via GitHub Actions trusted publishing with provenance attestations.
+This repository contains both JavaScript and Python packages, both published as `autoevals`:
+
+- npm package: `autoevals`
+- PyPI package: `autoevals`
+
+Publishing is handled via GitHub Actions trusted publishing.
+
+## Workflows
+
+Publishing workflows:
+
+- `.github/workflows/publish.yaml` — manual dispatcher that triggers both package publish workflows
+- `.github/workflows/publish-js.yaml` — npm publish workflow
+- `.github/workflows/publish-py.yaml` — PyPI publish workflow
+- `.github/workflows/version-sync.yaml` — CI check that JS/Python versions stay in sync
+
+## Versioning policy
+
+JavaScript and Python package versions must always match.
+
+The canonical version files are:
+
+- `package.json`
+- `py/autoevals/version.py`
+
+CI enforces this with:
+
+- `.github/workflows/version-sync.yaml`
+- `.github/scripts/check_version_sync.py`
+
+If these versions do not match, CI fails and publish workflows fail early.
+
+## Recommended publish flow
+
+Use the top-level `publish` workflow for normal releases.
+
+In GitHub Actions, manually run:
+
+- `publish`
+
+Inputs:
+
+- `release_type=stable` or `prerelease`
+- `branch=main` (or another branch to publish from)
+
+This workflow dispatches both:
+
+- `publish-js.yaml`
+- `publish-py.yaml`
+
+For prereleases, the dispatcher passes a shared prerelease suffix to both workflows so the releases stay aligned:
+
+- npm: `<version>-rc.<suffix>`
+- PyPI: `<version>rc<suffix>`
+
+Example for base version `0.2.0` and suffix `123`:
+
+- npm: `0.2.0-rc.123`
+- PyPI: `0.2.0rc123`
 
 ## JavaScript npm publishing
 
@@ -11,14 +69,14 @@ The JavaScript publish workflow lives at:
 It supports two release types:
 
 - `stable`: publishes the exact version in `package.json`
-- `prerelease`: publishes `<package.json version>-rc.<github run number>` with the `rc` dist-tag
+- `prerelease`: publishes `<package.json version>-rc.<suffix>` with the `rc` dist-tag
 
 For stable releases, the workflow also:
 
 - creates and pushes a git tag named `js-<version>`
-- creates a GitHub Release named `autoevals v<version>`
+- creates a GitHub Release named `autoevals JavaScript v<version>`
 
-## npm trusted publishing setup
+### npm trusted publishing setup
 
 Configure trusted publishing for the `autoevals` package in npm with these values:
 
@@ -27,35 +85,50 @@ Configure trusted publishing for the `autoevals` package in npm with these value
 - Repository owner: `braintrustdata`
 - Repository name: `autoevals`
 - Workflow file: `.github/workflows/publish-js.yaml`
-- Environment: `npm-publish`
 
 Notes:
 
 - The workflow uses GitHub OIDC, so no `NPM_TOKEN` is required.
 - The workflow publishes with provenance enabled via `npm publish --provenance`.
 
-## GitHub environment setup
+## Python PyPI publishing
 
-Create a GitHub Actions environment named:
+The Python publish workflow lives at:
 
-- `npm-publish`
+- `.github/workflows/publish-py.yaml`
 
-Recommended configuration:
+It supports two release types:
 
-- restrict deployments to `main`
-- add required reviewers if you want manual approval before publish
+- `stable`: publishes the exact version in `py/autoevals/version.py`
+- `prerelease`: publishes a PEP 440 prerelease version `<python version>rc<suffix>`
 
-The workflow already references this environment:
+For stable releases, the workflow also:
 
-```yaml
-environment: npm-publish
-```
+- creates and pushes a git tag named `py-<version>`
+- creates a GitHub Release named `autoevals Python v<version>`
+
+### PyPI trusted publishing setup
+
+Configure trusted publishing for the `autoevals` project in PyPI with these values:
+
+- Project name: `autoevals`
+- Owner: `braintrustdata`
+- Repository name: `autoevals`
+- Workflow file: `.github/workflows/publish-py.yaml`
+
+Notes:
+
+- The workflow uses GitHub OIDC, so no PyPI API token is required.
+- The workflow publishes via `pypa/gh-action-pypi-publish`.
+- The workflow must have `id-token: write` permission for trusted publishing.
 
 ## How to publish a stable release
 
-1. Bump the JavaScript package version in `package.json`.
+1. Bump both versions together:
+   - `package.json`
+   - `py/autoevals/version.py`
 2. Merge the change to `main`.
-3. In GitHub Actions, run the `publish-js` workflow.
+3. In GitHub Actions, run the `publish` workflow.
 4. Choose:
    - `release_type=stable`
    - `branch=main`
@@ -63,39 +136,67 @@ environment: npm-publish
 Expected outcome:
 
 - npm package `autoevals@<version>` is published
+- PyPI package `autoevals==<version>` is published
 - git tag `js-<version>` is created and pushed
-- GitHub Release `autoevals v<version>` is created
+- git tag `py-<version>` is created and pushed
+- GitHub Release `autoevals JavaScript v<version>` is created
+- GitHub Release `autoevals Python v<version>` is created
 
 ## How to publish a prerelease
 
-1. Make sure `package.json` contains the base version you want to prerelease from.
-2. In GitHub Actions, run the `publish-js` workflow.
+1. Make sure both version files contain the same base version:
+   - `package.json`
+   - `py/autoevals/version.py`
+2. In GitHub Actions, run the `publish` workflow.
 3. Choose:
    - `release_type=prerelease`
    - `branch=main`
 
 Expected outcome:
 
-- npm package `autoevals@<version>-rc.<run_number>` is published
+- npm package `autoevals@<version>-rc.<suffix>` is published
 - npm dist-tag `rc` is updated
-- no git tag is created
-- no GitHub Release is created
+- PyPI package `autoevals==<version>rc<suffix>` is published
+- no stable git tags are created
+- no GitHub Releases are created
 
-## Safeguards in the workflow
+## Publishing package-specific workflows directly
 
-The workflow will fail early if:
+If needed, you can manually trigger either workflow directly:
 
-- the stable tag `js-<version>` already exists on `origin`
+- `publish-js`
+- `publish-py`
+
+Both accept:
+
+- `release_type`
+- `branch`
+- `prerelease_suffix` (optional)
+
+Normally you should prefer the top-level `publish` workflow so JS and Python prereleases use the same suffix.
+
+## Safeguards in the workflows
+
+The workflows fail early if:
+
+- `package.json` and `py/autoevals/version.py` do not match
+- the stable JS tag `js-<version>` already exists on `origin`
+- the stable Python tag `py-<version>` already exists on `origin`
 - the npm version being published already exists
+- the PyPI version being published already exists
 
 ## Local validation
 
 Useful commands before triggering a release:
 
 ```bash
+python3 .github/scripts/check_version_sync.py
 pnpm install --frozen-lockfile
 pnpm run build
 npm publish --dry-run --access public
+python3 -m pip install --upgrade build twine
+python3 -m build
+python3 -m twine check dist/*
 ```
 
 ## Historical releases and source mapping
@@ -105,8 +206,6 @@ Older npm releases may not be traceable back to an exact git commit from npm alo
 - npm metadata for older releases may not include `gitHead`
 - those releases do not have OIDC/provenance attestations tying the package to a workflow run and commit
 
-For those historical versions, the best commit mapping may need to be inferred from repository history, publish timestamps, and version bumps. New releases published through `.github/workflows/publish-js.yaml` are expected to be easier to trace because they use trusted publishing with provenance.
+For those historical versions, the best commit mapping may need to be inferred from repository history, publish timestamps, and version bumps. New npm releases published through `.github/workflows/publish-js.yaml` are easier to trace because they use trusted publishing with provenance.
 
-## Future publishing work
-
-Python publishing is not yet covered by this document. When a Python release workflow is added, keep Python tags and release process separate from the JavaScript `js-<version>` tag namespace.
+Python releases published through `.github/workflows/publish-py.yaml` are similarly expected to be easier to trace because they use PyPI trusted publishing via GitHub Actions OIDC.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoevals",
-  "version": "0.0.132",
+  "version": "0.2.0",
   "description": "Universal library for evaluating AI models",
   "repository": {
     "type": "git",

--- a/py/autoevals/version.py
+++ b/py/autoevals/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.0"
+VERSION = "0.2.0"


### PR DESCRIPTION
Part 2 for https://github.com/braintrustdata/autoevals/pull/180

adds pypi trusted publishing, and then unifies the release process to publish both python and javascript libraries at once. Also bumps versions, so can test cutting a release after this.