### PR TITLE
ci(publish-js): align pnpm version with mise

### DIFF
--- a/.github/workflows/publish-js.yaml
+++ b/.github/workflows/publish-js.yaml
@@ -115,7 +115,7 @@ jobs:
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
-          version: 10.26.2
+          version: 10.33.0
 
       - name: Check npm version availability
         run: |


### PR DESCRIPTION
Use pnpm 10.33.0 in the publish-js workflow to match package.json and mise.toml.

This fixes the GitHub Actions failure caused by pnpm/action-setup rejecting multiple pnpm versions.