### PR TITLE
docs: add ExactMatch score example

### DIFF
--- a/SCORERS.md
+++ b/SCORERS.md
@@ -406,6 +406,18 @@ Binary scorer that checks for exact string equality.
 - `1` = Values are exactly equal
 - `0` = Values differ
 
+**Example:**
+
+```python
+from autoevals import ExactMatch
+
+scorer = ExactMatch()
+result = scorer.eval(output="hello", expected="hello")
+
+print(result.name)   # ExactMatch
+print(result.score)  # 1
+```
+
 ### NumericDiff
 
 Evaluates numeric differences with configurable thresholds.


### PR DESCRIPTION
## What changed

Adds a small `ExactMatch` example to `SCORERS.md` showing the returned score object fields users usually inspect: `name` and `score`.

## Why

The surrounding section already documents the binary `0` / `1` score range, but the concrete returned object shape was less visible than in nearby scorer examples.

## Validation

Ran locally:

```bash
git diff --check
```
