### PR TITLE
docs: document score result shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,21 @@ Nicolo also dropped this as a reference: http://spec.openapis.org/oas/v3.0.3#ope
 
 </div>
 
+## Score results
+
+Every scorer returns a small `Score` result object. This is the public surface
+consumers should read when they need to store, compare, or export evaluation
+results:
+
+- `name`: the scorer name
+- `score`: a number between 0 and 1, or `None` / `null` when the evaluation is skipped
+- `metadata`: optional scorer-specific details, such as rationale text or a
+  selected choice
+- `error`: deprecated; errors are propagated to the caller in current versions
+
+Inputs, expected values, model prompts, and other runtime context are not part
+of the `Score` object. Keep those separately if your application needs them.
+
 ## Creating custom scorers
 
 You can also create your own scoring functions that do not use LLMs. For example, to test whether the word `'banana'`

--- a/README.md
+++ b/README.md
@@ -463,7 +463,8 @@ results:
 - `score`: a number between 0 and 1, or `None` / `null` when the evaluation is skipped
 - `metadata`: optional scorer-specific details, such as rationale text or a
   selected choice
-- `error`: deprecated; errors are propagated to the caller in current versions
+- `error`: deprecated and retained for backward compatibility; some scorers may
+  still populate it, but callers should primarily handle thrown exceptions
 
 Inputs, expected values, model prompts, and other runtime context are not part
 of the `Score` object. Keep those separately if your application needs them.

--- a/README.md
+++ b/README.md
@@ -462,7 +462,8 @@ results:
 - `name`: the scorer name
 - `score`: a number between 0 and 1, or `None` / `null` when the evaluation is skipped
 - `metadata`: optional scorer-specific details, such as rationale text or a
-  selected choice
+  selected choice. Keys are scorer-specific; consumers should not assume
+  metadata keys are shared across scorer types.
 - `error`: deprecated and retained for backward compatibility; some scorers may
   still populate it, but callers should primarily handle thrown exceptions
 


### PR DESCRIPTION
## Summary

Documents the small `Score` result object returned by scorers in the README.

The new section calls out the public fields consumers should read when storing, comparing, or exporting evaluation results: `name`, `score`, `metadata`, and the deprecated `error` field. It also clarifies that inputs, expected values, prompts, and runtime context are kept separately from the returned `Score`.

## Context

This follows the public-surface clarification from #187, where maintainers confirmed the returned `Score` object is the right minimal scorer-consumer boundary.

## Validation

- `git diff --check`
