### PR TITLE
[Deps] Pin braintrust <0.13 to unbreak Python CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,10 @@ install_requires = ["chevron", "polyleven", "pyyaml", "jsonschema"]
 extras_require = {
     "dev": [
         "black==22.6.0",
-        "braintrust",  # used for testing
+        # 0.13.0 removed the wrapper classes (ChatCompletionV0Wrapper, OpenAIV1Wrapper, ...)
+        # and changed wrap_openai so it no longer returns a NamedWrapper, which breaks
+        # test_oai.py imports and LLMClient.is_wrapped detection. Cap until autoevals is updated.
+        "braintrust<0.13",  # used for testing
         "build",
         "flake8",
         "flake8-isort",


### PR DESCRIPTION
## Summary

**[Deps] Pin braintrust <0.13 to unbreak Python CI**
* `braintrust` 0.13.0 removed the wrapper classes (`ChatCompletionV0Wrapper`, `OpenAIV1Wrapper`, …) and changed `wrap_openai` to no longer return a `NamedWrapper`. `test_oai.py` imports those at module load, so pytest collection aborts and the whole Python job fails on **every** PR (deps are installed unpinned).
* caps at the last compatible release (0.12.1). stopgap — adapting autoevals to braintrust ≥0.13 (incl. `LLMClient.is_wrapped`) is follow-up.

PTAL:
FYI:

## Test plan

* [x] `pytest py/autoevals/test_oai.py` → 17 passed on 0.12.1 (was: collection ImportError on 0.23)
* [x] full `test_llm.py` + `test_oai.py` green on 0.12.1

## Other Notes

* found while diagnosing red CI on #190 (which is unrelated — a feature PR).