### PR TITLE
[OAI] Support braintrust >=0.13 wrapping (fix Python CI)

### DIFF
--- a/py/autoevals/oai.py
+++ b/py/autoevals/oai.py
@@ -9,6 +9,15 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any, Optional, Protocol, TypedDict, TypeVar, Union, cast, runtime_checkable
 
+try:
+    # Braintrust (>= 0.13) patches OpenAI resource methods with wrapt wrappers.
+    # wrapt is a Braintrust dependency, so it's present whenever wrapping can occur.
+    from wrapt import BoundFunctionWrapper, FunctionWrapper
+
+    _WRAPT_WRAPPER_TYPES: tuple[type, ...] = (FunctionWrapper, BoundFunctionWrapper)
+except ImportError:
+    _WRAPT_WRAPPER_TYPES = ()
+
 PROXY_URL = "https://api.braintrust.dev/v1/proxy"
 
 
@@ -126,6 +135,33 @@ def is_gpt5_model(model: str) -> bool:
     return model.startswith("gpt-5")
 
 
+def openai_client_is_wrapped(client: Any, named_wrapper: type) -> bool:
+    """Detect whether an OpenAI client has been instrumented by Braintrust.
+
+    Works across Braintrust versions:
+    - < 0.13 wrapped the whole client in a ``NamedWrapper`` proxy.
+    - >= 0.13 patches resource methods in place, replacing ``create`` with a
+      ``wrapt`` function wrapper while leaving the client object unchanged.
+      Note: >= 0.13 only instruments the v1 SDK, so v0 clients are no longer
+      traced. (``create`` exposes ``__wrapped__`` even when unwrapped, so we
+      check the wrapper type rather than that attribute.)
+    """
+    if isinstance(client, named_wrapper):
+        return True
+    if not _WRAPT_WRAPPER_TYPES:
+        return False
+    for path in (("chat", "completions", "create"), ("responses", "create")):
+        obj = client
+        for attr in path:
+            obj = getattr(obj, attr, None)
+            if obj is None:
+                break
+        else:
+            if isinstance(obj, _WRAPT_WRAPPER_TYPES):
+                return True
+    return False
+
+
 @dataclass
 class LLMClient:
     """A client wrapper for LLM operations that supports both OpenAI SDK v0 and v1.
@@ -192,10 +228,12 @@ class LLMClient:
         has_customization = self.complete is not None or self.embed is not None or self.moderation is not None  # type: ignore  # Pyright doesn't understand our design choice
 
         # avoid wrapping if we have custom methods (the user may intend not to wrap)
-        if not has_customization and not isinstance(self.openai, NamedWrapper):
+        # wrap_openai is idempotent (braintrust >= 0.13) / returns a NamedWrapper proxy
+        # (< 0.13), so it's safe to call whenever the client isn't already wrapped.
+        if not has_customization and not openai_client_is_wrapped(self.openai, NamedWrapper):
             self.openai = wrap_openai(self.openai)
 
-        self._is_wrapped = isinstance(self.openai, NamedWrapper)
+        self._is_wrapped = openai_client_is_wrapped(self.openai, NamedWrapper)
 
         openai_module = get_openai_module()
 

--- a/py/autoevals/test_oai.py
+++ b/py/autoevals/test_oai.py
@@ -4,11 +4,7 @@ from typing import Any, cast
 import openai
 import pytest
 from braintrust.oai import (
-    ChatCompletionV0Wrapper,
-    CompletionsV1Wrapper,
     NamedWrapper,
-    OpenAIV0Wrapper,
-    OpenAIV1Wrapper,
     wrap_openai,
 )
 from openai.resources.chat.completions import AsyncCompletions
@@ -27,7 +23,9 @@ from autoevals.oai import (  # type: ignore[import]
 
 
 def unwrap_named_wrapper(obj: NamedWrapper | OpenAIV1Module.OpenAI | OpenAIV0Module) -> Any:
-    return getattr(obj, "_NamedWrapper__wrapped")
+    # braintrust < 0.13 wrapped clients in a NamedWrapper proxy; >= 0.13 patches the
+    # client in place, so there's nothing to unwrap and we return it as-is.
+    return getattr(obj, "_NamedWrapper__wrapped", obj)
 
 
 @pytest.fixture(autouse=True)
@@ -83,8 +81,8 @@ def test_init_creates_async_llmclient_if_needed(mock_openai_v0: OpenAIV0Module):
     prepared_client = prepare_openai()
 
     assert isinstance(prepared_client, LLMClient)
-    assert prepared_client.is_wrapped
-    assert isinstance(prepared_client.openai, OpenAIV0Wrapper)
+    # braintrust >= 0.13 only instruments the v1 SDK, so v0 clients are not wrapped.
+    assert not prepared_client.is_wrapped
     assert prepared_client.complete.__name__ == "acreate"
 
 
@@ -106,7 +104,8 @@ def test_prepare_openai_with_plain_openai():
     prepared_client = prepare_openai(client=client)
 
     assert prepared_client.is_wrapped
-    assert isinstance(prepared_client.openai, OpenAIV1Wrapper)
+    # braintrust >= 0.13 patches the client in place rather than returning a proxy.
+    assert prepared_client.openai is client
 
 
 def test_prepare_openai_async():
@@ -114,7 +113,7 @@ def test_prepare_openai_async():
 
     assert isinstance(prepared_client, LLMClient)
     assert prepared_client.is_wrapped
-    assert isinstance(prepared_client.openai, OpenAIV1Wrapper)
+    assert isinstance(prepared_client.openai, openai.AsyncOpenAI)
 
     assert callable(prepared_client.complete)
     assert prepared_client.complete.__name__ == "complete_wrapper"
@@ -228,16 +227,17 @@ def mock_openai_v0(monkeypatch: pytest.MonkeyPatch):
 def test_prepare_openai_v0_sdk(mock_openai_v0: OpenAIV0Module):
     prepared_client = prepare_openai()
 
-    assert prepared_client.is_wrapped
+    # braintrust >= 0.13 only instruments the v1 SDK, so v0 clients are not wrapped.
+    assert not prepared_client.is_wrapped
     assert prepared_client.openai.api_key == "test-key"
-
-    assert isinstance(getattr(prepared_client.complete, "__self__", None), ChatCompletionV0Wrapper)
+    assert prepared_client.complete.__name__ == "create"
 
 
 def test_prepare_openai_v0_async(mock_openai_v0: OpenAIV0Module):
     prepared_client = prepare_openai(is_async=True)
 
-    assert prepared_client.is_wrapped
+    # braintrust >= 0.13 only instruments the v1 SDK, so v0 clients are not wrapped.
+    assert not prepared_client.is_wrapped
     assert prepared_client.openai.api_key == "test-key"
 
     assert prepared_client.complete.__name__ == "acreate"
@@ -248,7 +248,8 @@ def test_prepare_openai_v0_with_client(mock_openai_v0: OpenAIV0Module):
 
     prepared_client = prepare_openai(client=client)
 
-    assert prepared_client.is_wrapped
+    # braintrust >= 0.13 only instruments the v1 SDK, so v0 clients are not wrapped.
+    assert not prepared_client.is_wrapped
     assert prepared_client.openai.api_key is mock_openai_v0.api_key  # must be set by the user
     assert prepared_client.complete.__name__ == "acreate"
 


### PR DESCRIPTION
## Summary

**[OAI] Support braintrust >=0.13 wrapping (fix Python CI)**
* braintrust 0.13 changed `wrap_openai` to patch methods in place (wrapt) instead of returning a `NamedWrapper`, and dropped the `*Wrapper` classes — breaking `is_wrapped` detection and `test_oai.py`'s imports (collection abort → red Python CI on every PR).
* fix-forward (no pin): detect wrapping version-agnostically — `NamedWrapper` (<0.13) or wrapt wrapper on `create()` (>=0.13).
* behavior change: >=0.13 only instruments the v1 SDK, so v0 clients are no longer traced. tests updated.

PTAL:
FYI:

## Test plan

* [x] `pytest py/autoevals/` → 68 passed on braintrust 0.23 (was: collection ImportError)
* [x] manual sanity check below — verifies detection + a real classifier completing through the wrapped client (so the injected braintrust span metadata doesn't break the call):

```
braintrust 0.23.0
OK: wrapping detection works (structural)
OK: live classifier through wrapped client -> score=1
```

<details><summary><code>check_braintrust_wrapping.py</code> (run it yourself)</summary>

```python
"""Sanity check: autoevals still works with the installed braintrust.

braintrust periodically changes how wrap_openai instruments OpenAI clients
(e.g. 0.13 moved from a NamedWrapper proxy to in-place wrapt patching). If
detection regresses, scorer spans silently lose their `purpose` -- and the
injected span metadata could even break the wrapped call. Run this after a
braintrust upgrade to confirm nothing regressed.

  # structural checks only (no network/key):
  python check_braintrust_wrapping.py

  # also run a real classifier through the wrapped client:
  BRAINTRUST_API_KEY=... python check_braintrust_wrapping.py
"""

import importlib.metadata as md
import os

import openai
from braintrust.oai import wrap_openai

from autoevals import Factuality, init
from autoevals.oai import LLMClient, get_openai_wrappers, openai_client_is_wrapped, prepare_openai

print("braintrust", md.version("braintrust"))
NamedWrapper, _ = get_openai_wrappers()

# 1. helper detects a wrapped client and does not false-positive on a plain one.
wrapped = wrap_openai(openai.OpenAI(api_key="x"))
plain = openai.OpenAI(api_key="x")
assert openai_client_is_wrapped(wrapped, NamedWrapper), "wrapped client not detected"
assert not openai_client_is_wrapped(plain, NamedWrapper), "plain client falsely detected"

# 2. init() -> prepare_openai() wraps the default client and reports is_wrapped.
init(openai.OpenAI(api_key="x"))
assert prepare_openai().is_wrapped, "prepare_openai() did not wrap"

# 3. a client with custom methods opts out of wrapping.
init(None)
custom = openai.OpenAI(api_key="x")
assert not LLMClient(openai=custom, complete=custom.chat.completions.create).is_wrapped
print("OK: wrapping detection works (structural)")

# 4. live: run a real classifier through the wrapped client. The wrapped call
#    must accept the injected braintrust span metadata and return a score.
if os.environ.get("OPENAI_API_KEY") or os.environ.get("BRAINTRUST_API_KEY"):
    init(None)  # default client -> braintrust proxy + BRAINTRUST_API_KEY
    assert prepare_openai().is_wrapped
    r = Factuality(model="gpt-4o-mini").eval(
        output="Paris", expected="Paris", input="What is the capital of France?"
    )
    assert r.error is None, r.error
    assert r.score == 1, r.score
    print(f"OK: live classifier through wrapped client -> score={r.score}")
else:
    print("SKIP live classifier (set BRAINTRUST_API_KEY or OPENAI_API_KEY to run it)")
```

</details>

## Other Notes

* supersedes #192 (pin); surfaced while diagnosing #190.
