### PR TITLE
autoevals: support Zod v4 via peer dependency

### DIFF
--- a/js/ragas.ts
+++ b/js/ragas.ts
@@ -109,7 +109,7 @@ import OpenAI from "openai";
 import { ListContains } from "./list";
 import { EmbeddingSimilarity } from "./string";
 import { z } from "zod";
-import zodToJsonSchema from "zod-to-json-schema";
+import { zodToJsonSchema } from "./zod-utils";
 import { makePartial, ScorerWithPartial } from "./partial";
 
 type RagasArgs = {

--- a/js/zod-utils.ts
+++ b/js/zod-utils.ts
@@ -1,0 +1,22 @@
+import { zodToJsonSchema as zodToJsonSchemaV3 } from "zod-to-json-schema";
+import * as z3 from "zod/v3";
+import * as z4 from "zod/v4";
+
+function isZodV4(zodObject: z3.ZodType | z4.ZodType): zodObject is z4.ZodType {
+  return (
+    typeof zodObject === "object" &&
+    zodObject !== null &&
+    "_zod" in zodObject &&
+    zodObject._zod !== undefined
+  );
+}
+
+export function zodToJsonSchema(schema: z4.ZodType | z3.ZodType) {
+  if (isZodV4(schema)) {
+    return z4.toJSONSchema(schema, {
+      target: "draft-7",
+    });
+  }
+
+  return zodToJsonSchemaV3(schema);
+}

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "typedoc": "^0.25.13",
     "typedoc-plugin-markdown": "^3.17.1",
     "typescript": "^5.9.2",
-    "vitest": "^2.1.9"
+    "vitest": "^2.1.9",
+    "zod": "^3.25.34"
   },
   "dependencies": {
     "ajv": "^8.17.1",
@@ -65,8 +66,10 @@
     "linear-sum-assignment": "^1.0.7",
     "mustache": "^4.2.0",
     "openai": "^6.3.0",
-    "zod": "^3.25.76",
     "zod-to-json-schema": "^3.24.6"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.34 || ^4.0"
   },
   "packageManager": "pnpm@10.33.0"
 }


### PR DESCRIPTION
## Summary

- Moves `zod` from a hard dependency to a peer dependency with range `^3.25.34 || ^4.0`, mirroring the pattern already in use in the main `braintrust` TypeScript SDK. Users on either Zod major can now consume autoevals without allowing duplicate Zod installs or patching the build locally.
- Adds `js/zod-utils.ts` — a direct port of the `zodToJsonSchema` shim at `braintrust/sdk/js/src/zod/utils.ts`. Dispatches Zod v3 schemas through `zod-to-json-schema` and Zod v4 schemas through v4's native `z.toJSONSchema()`.
- Updates `js/ragas.ts` to import the shim. `js/templates.ts` works as-is since it uses only basic Zod APIs that exist in both majors.
- Reported by Juicebox (Pylon #17165), tracked in Linear as BT-5495.

## Relationship to prior work

This supersedes #155 (Caitlin's draft from December 2025). That branch had the right idea but accumulated unrelated drift from a stale base (changes to `init-models.test.ts`, `llm.fixtures.ts` model strings, `thread-utils` exports, etc.). I started fresh from current `main` and applied only the minimal change needed for Zod v4 compat.

Closes #155 if/when this lands.

## Reviewer note: internal integration tests

Caitlin flagged on 2026-01-13 in #155 that her version of this change was failing some internal integration tests that weren't covered by autoevals' public CI. **Those tests still need to be re-validated against this PR.** Public CI on this branch should pass cleanly since the change matches the proven SDK pattern, but the internal failures she saw could re-appear in whichever monorepo consumes autoevals.

If they do, the most likely sources are:

- Type incompatibility between autoevals' built types and the consumer monorepo's Zod version. The `modelGradedSpecSchema` export type now resolves to the consumer's installed Zod, which could break if the monorepo mixes Zod v3 and v4 in the same module graph.
- Subpath imports (`zod/v3`, `zod/v4`) requiring Zod 3.25+ — older Zod 3.x versions don't ship those subpaths.

Happy to debug whichever specific tests fail; just need pointer to the failing CI run.

## Test plan

- [ ] Public CI (build, lint, evals) passes on this branch.
- [ ] Install autoevals into a project pinned to `zod@^3.25.34` — confirm runtime + types work.
- [ ] Install autoevals into a project pinned to `zod@^4.0` — confirm runtime + types work.
- [ ] Run autoevals' internal integration tests in whichever monorepo Caitlin saw failing previously — confirm those resolve.
- [ ] Verify `ragas` scorer (`ContextRelevancy`, `Faithfulness`, etc.) still produces correct JSON Schema output for OpenAI tool params, on both Zod versions.
