### PR TITLE
ci(publish): clear npm tokens for trusted publishing

### DIFF
--- a/.github/workflows/publish-js.yaml
+++ b/.github/workflows/publish-js.yaml
@@ -146,10 +146,16 @@ jobs:
 
       - name: Publish stable release to npm
         if: ${{ env.RELEASE_TYPE == 'stable' }}
+        env:
+          NODE_AUTH_TOKEN: ""
+          NPM_TOKEN: ""
         run: npm publish --provenance --access public
 
       - name: Publish prerelease to npm
         if: ${{ env.RELEASE_TYPE == 'prerelease' }}
+        env:
+          NODE_AUTH_TOKEN: ""
+          NPM_TOKEN: ""
         run: npm publish --tag rc --provenance --access public
 
       - name: Create and push stable release tag


### PR DESCRIPTION
Clear NODE_AUTH_TOKEN and NPM_TOKEN on the npm publish steps so npm uses GitHub OIDC trusted publishing instead of an injected token from setup-node.

The failed autoevals@0.3.0 release had a NODE_AUTH_TOKEN present during npm publish, which caused npm to attempt token-based publishing and return a misleading 404 for the package. This mirrors the working publish setup in braintrust-sdk-javascript while preserving provenance publishing for both stable and prerelease releases.