### PR TITLE
ci(publish): use tool versions for Node release runtime

### DIFF
--- a/.github/workflows/publish-js.yaml
+++ b/.github/workflows/publish-js.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22
+          node-version-file: .tool-versions
       - name: Determine release metadata
         id: release_metadata
         env:
@@ -110,7 +110,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22
+          node-version-file: .tool-versions
           registry-url: https://registry.npmjs.org
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,4 @@
 python 3.13.5
+nodejs 24.15.0
+npm 11.12.1
+pnpm 10.33.0


### PR DESCRIPTION
Configure the JavaScript publish workflow to read Node from .tool-versions and add the same Node, npm, and pnpm tool versions used by the working braintrust-sdk-javascript publish flow.

The previous rerun cleared npm token environment variables correctly, but the GitHub runner's Node 22 image used npm 10.9.8 and failed trusted publishing with ENEEDAUTH. Moving the publish workflow to Node 24 gives it npm 11 support for GitHub OIDC trusted publishing without a one-off npm install step.