### PR TITLE
fix: `AnswerRelevancy` silently ignores `embedding_model` (both sync and async)

### DIFF
--- a/py/autoevals/ragas.py
+++ b/py/autoevals/ragas.py
@@ -1179,8 +1179,8 @@ class AnswerRelevancy(OpenAILLMScorer):
         )
         similarity = await asyncio.gather(
             *[
-                EmbeddingSimilarity(client=self.client).eval_async(
-                    output=q["question"], expected=input, model=self.embedding_model
+                EmbeddingSimilarity(client=self.client, model=self.embedding_model).eval_async(
+                    output=q["question"], expected=input
                 )
                 for q in questions
             ]
@@ -1199,8 +1199,8 @@ class AnswerRelevancy(OpenAILLMScorer):
             for _ in range(self.strictness)
         ]
         similarity = [
-            EmbeddingSimilarity(client=self.client).eval(
-                output=q["question"], expected=input, model=self.embedding_model
+            EmbeddingSimilarity(client=self.client, model=self.embedding_model).eval(
+                output=q["question"], expected=input
             )
             for q in questions
         ]

--- a/py/autoevals/test_ragas.py
+++ b/py/autoevals/test_ragas.py
@@ -4,11 +4,12 @@ import json
 import pytest
 import respx
 from httpx import Response
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
 
 import autoevals.ragas as ragas_module
 from autoevals import init
 from autoevals.ragas import *
+
 
 data = {
     "input": "Can starred docs from different workspaces be accessed in one place?",
@@ -262,3 +263,135 @@ def test_answer_correctness_uses_custom_embedding_model():
     )
 
     assert captured_embedding_model == "text-embedding-3-large"
+
+
+def _make_answer_relevancy_mocks(question: str):
+    """Build respx side effects for AnswerRelevancy: question generation + embeddings capture.
+
+    Returns (captured_embedding_models, chat_mock, responses_mock, embeddings_mock).
+    The question must be unique per test because EmbeddingSimilarity caches embeddings
+    by input text, so a repeated question would skip the embeddings API entirely.
+    """
+    captured_embedding_models = []
+
+    def mock_chat_completions(request):
+        return Response(
+            200,
+            json={
+                "id": "test-id",
+                "object": "chat.completion",
+                "created": 1234567890,
+                "model": "gpt-5-mini",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "tool_calls": [
+                                {
+                                    "id": "call_test",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "generate_question",
+                                        "arguments": json.dumps({"question": question, "noncommittal": 0}),
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+            },
+        )
+
+    def mock_responses_api(request):
+        return Response(
+            200,
+            json={
+                "id": "test-id",
+                "object": "response",
+                "created": 1234567890,
+                "model": "gpt-5-mini",
+                "output": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call_test",
+                        "name": "generate_question",
+                        "arguments": json.dumps({"question": question, "noncommittal": 0}),
+                    }
+                ],
+            },
+        )
+
+    def mock_embeddings(request):
+        data = json.loads(request.content.decode())
+        captured_embedding_models.append(data.get("model"))
+        return Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {
+                        "object": "embedding",
+                        "embedding": [0.1] * 1536,
+                        "index": 0,
+                    }
+                ],
+                "model": data.get("model"),
+                "usage": {"prompt_tokens": 5, "total_tokens": 5},
+            },
+        )
+
+    return captured_embedding_models, mock_chat_completions, mock_responses_api, mock_embeddings
+
+
+@respx.mock
+def test_answer_relevancy_uses_custom_embedding_model():
+    """Test that AnswerRelevancy passes embedding_model through to the embeddings API (#166)."""
+    captured, chat_mock, responses_mock, embeddings_mock = _make_answer_relevancy_mocks(
+        question="What is the sync capital of France?"
+    )
+
+    respx.post("https://api.openai.com/v1/chat/completions").mock(side_effect=chat_mock)
+    respx.post("https://api.openai.com/v1/responses").mock(side_effect=responses_mock)
+    respx.post("https://api.openai.com/v1/embeddings").mock(side_effect=embeddings_mock)
+
+    init(OpenAI(api_key="test-api-key", base_url="https://api.openai.com/v1"))
+
+    # Pin a chat-completions model so question generation hits the mocked endpoint above.
+    metric = AnswerRelevancy(model="gpt-4o-mini", embedding_model="text-embedding-3-large", strictness=1)
+    metric.eval(
+        input="What is the sync capital of France?!",
+        output="Paris",
+        context="Paris is the capital of France.",
+    )
+
+    assert captured, "expected at least one embeddings API call"
+    assert all(model == "text-embedding-3-large" for model in captured), captured
+
+
+@respx.mock
+def test_answer_relevancy_uses_custom_embedding_model_async():
+    """Test that AnswerRelevancy passes embedding_model through to the embeddings API in the async path (#166)."""
+    captured, chat_mock, responses_mock, embeddings_mock = _make_answer_relevancy_mocks(
+        question="What is the async capital of France?"
+    )
+
+    respx.post("https://api.openai.com/v1/chat/completions").mock(side_effect=chat_mock)
+    respx.post("https://api.openai.com/v1/responses").mock(side_effect=responses_mock)
+    respx.post("https://api.openai.com/v1/embeddings").mock(side_effect=embeddings_mock)
+
+    init(AsyncOpenAI(api_key="test-api-key", base_url="https://api.openai.com/v1"))
+
+    # Pin a chat-completions model so question generation hits the mocked endpoint above.
+    metric = AnswerRelevancy(model="gpt-4o-mini", embedding_model="text-embedding-3-large", strictness=1)
+    asyncio.run(
+        metric.eval_async(
+            input="What is the async capital of France?!",
+            output="Paris",
+            context="Paris is the capital of France.",
+        )
+    )
+
+    assert captured, "expected at least one embeddings API call"
+    assert all(model == "text-embedding-3-large" for model in captured), captured


### PR DESCRIPTION
Fixes #166.

The bug is broader than #166 describes: `embedding_model` is ignored in **both** the sync and async paths, not just sync.

`AnswerRelevancy` passes the model at eval time:

    EmbeddingSimilarity(client=self.client).eval(output=..., expected=..., model=self.embedding_model)

but `EmbeddingSimilarity` only reads `model` in its **constructor** (stored into `self.extra_args`). At eval time the kwarg lands in the `**kwargs` of `_run_eval_sync` / `_run_eval_async` and is never used — so every `AnswerRelevancy` run silently embeds with the default model, regardless of what the caller configured.

#164 fixed half of this (the sync path was passing `self.model` — the judge LLM — instead of `self.embedding_model`), but the corrected value still went to the call site, where it's dropped. #167 had the right approach (constructor, not call site) but no test coverage; this PR completes it.

**Fix:** pass `model=self.embedding_model` to the `EmbeddingSimilarity` constructor in both paths. `embedding_model=None` remains safe (the constructor falls back to `get_default_embedding_model()`).

**Tests:** two regression tests (sync + async) following the pattern of `test_answer_correctness_uses_custom_embedding_model` — respx captures the `model` field actually sent to `/v1/embeddings`. On `main` both fail with `['text-embedding-ada-002', ...]`; with the fix both pass. The tests pin `model="gpt-4o-mini"` for question generation so the mocked chat-completions endpoint is used (gpt-5-class defaults route through the Responses API).

Found while preparing to use `AnswerRelevancy` with a custom embedding model for a RAG eval harness.