### PR TITLE
fix: allow npm consumers to install the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,6 @@
     "docs": "npx typedoc --options typedoc.json js/index.ts",
     "test": "vitest"
   },
-  "engines": {
-    "pnpm": ">=10.27.0",
-    "npm": "please-use-pnpm",
-    "yarn": "please-use-pnpm"
-  },
   "author": "",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Fixes #212

## Summary

- remove package-manager restrictions from the published `engines` metadata so npm consumers with `engine-strict=true` can install `autoevals`
- keep repository development pinned to pnpm through the existing `packageManager`, root-only `preinstall` check, and lockfile CI gate

npm validates every published `engines` entry for consumers, so the pnpm/npm/yarn-only metadata made a normal dependency install fail before the package could be used.

## Validation

- fail-first: packed current `main`, then installed the tarball from an npm consumer with `engine-strict=true`; npm 11.6.2 failed with `EBADENGINE`
- packed this branch and repeated the same consumer install; installation succeeded and `import("autoevals")` exposed `ExactMatch`
- `pnpm exec vitest run` on the 9 offline JS test files: 66 passed
- `pnpm run build`
- `git diff --check`

The remaining live-API Vitest files require OpenAI/Braintrust credentials and were not run locally.

Disclosure: this contribution was prepared with OpenAI Codex.
