### PR TITLE
fix: return ExactMatch mismatches for non-JSON primitives

### DIFF
--- a/py/autoevals/test_values.py
+++ b/py/autoevals/test_values.py
@@ -1,4 +1,4 @@
-from pytest import approx
+from pytest import approx, mark
 
 from autoevals.list import ListContains
 from autoevals.number import NumericDiff
@@ -105,3 +105,11 @@ def test_exact_match():
             expected,
             expected_score,
         )
+
+
+@mark.parametrize("reference", [{"amount": 100}, [100]])
+@mark.parametrize("non_json", [None, True, 100, 1.5])
+def test_exact_match_json_and_non_json_values(reference, non_json):
+    evaluator = ExactMatch()
+    assert evaluator(output=non_json, expected=reference).score == 0
+    assert evaluator(output=reference, expected=non_json).score == 0

--- a/py/autoevals/value.py
+++ b/py/autoevals/value.py
@@ -84,7 +84,7 @@ def normalize_value(value: Any, maybe_object: bool) -> str:
     try:
         if maybe_object:
             return json.dumps(json.loads(value))
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, TypeError):
         pass
 
     return str(value)


### PR DESCRIPTION
## Summary

`ExactMatch()(output=None, expected={"amount": 100})` currently raises `TypeError` instead of returning a mismatch score. The same happens for booleans and numbers compared with a dict or list, including when the arguments are reversed. These comparisons now return `0`, using the existing normalization fallback.

## Validation

- All 8 new parameterized cases failed before the fix.
- `pytest py/autoevals/test_values.py py/autoevals/test_json.py -q`: 16 passed after the fix.
- Black, Flake8, and `git diff --check` passed for the changed files.
- Manually checked async evaluation, partial scorers, and existing bytes/bytearray JSON normalization.

The broader Python suite was attempted but is not green in this Windows environment: optional LiteLLM is missing, live API tests lack valid credentials, and the checkout's template symlink is not resolved.

## Post-deploy validation

No service deployment is involved. After a package release, the example above should return a score of `0`; I can help investigate any reported normalization regression.
