### PR TITLE
fix(python): honor ValidJSON schemas across scorer call paths

### DIFF
--- a/py/autoevals/json.py
+++ b/py/autoevals/json.py
@@ -250,10 +250,15 @@ class ValidJSON(ScorerWithPartial):
     def __init__(self, schema=None):
         self.schema = schema
 
-    def _run_eval_sync(self, output, schema=None, **kwargs):
+    def _run_eval_sync(self, output, expected=None, schema=None, **kwargs):
+        # Preserve the existing second-positional-argument schema convention.
+        if schema is None:
+            schema = expected
         return Score(name=self._name(), score=self.valid_json(output, schema))
 
     def valid_json(self, output, schema=None):
+        if schema is None:
+            schema = self.schema
         try:
             parsed = json.loads(output) if isinstance(output, str) else output
 

--- a/py/autoevals/test_json.py
+++ b/py/autoevals/test_json.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest import approx
 
 from autoevals.json import JSONDiff, ValidJSON
@@ -123,6 +124,38 @@ def test_valid_json():
     for output, expected, schema in cases:
         print(f"[{output}]", expected)
         assert evaluator(output, schema).score == expected
+
+
+@pytest.mark.parametrize(
+    "output, expected_score", [({}, 0), ({"answer": "yes"}, 1), ("{}", 0), ('{"answer":"yes"}', 1)]
+)
+@pytest.mark.parametrize("schema_source", ["constructor", "keyword", "positional", "partial"])
+@pytest.mark.asyncio
+async def test_valid_json_schema_calling_conventions(output, expected_score, schema_source):
+    schema = {"type": "object", "required": ["answer"]}
+    scorer = ValidJSON()
+    args = ()
+    kwargs = {}
+    if schema_source == "constructor":
+        scorer = ValidJSON(schema=schema)
+    elif schema_source == "keyword":
+        kwargs["schema"] = schema
+    elif schema_source == "positional":
+        args = (schema,)
+    else:
+        scorer = ValidJSON.partial(schema=schema)()
+
+    assert scorer.eval(output, *args, **kwargs).score == expected_score
+    assert scorer(output, *args, **kwargs).score == expected_score
+    assert (await scorer.eval_async(output, *args, **kwargs)).score == expected_score
+
+
+@pytest.mark.parametrize("schema", [{}, True, False])
+def test_valid_json_call_schema_overrides_constructor(schema):
+    scorer = ValidJSON(schema={"type": "object", "required": ["answer"]})
+    assert scorer.eval({}, schema=schema).score == (0 if schema is False else 1)
+    assert scorer.eval({}).score == 0
+    assert scorer.valid_json({}) == 0
 
 
 def test_semantic_json():


### PR DESCRIPTION
## Summary

Fix Python `ValidJSON` schema handling across constructor, keyword, positional, and partial scorer calls.

Two model-free repros on current main:

```python
schema = {"type": "object", "required": ["answer"]}
ValidJSON(schema=schema).eval({}).score  # 1, but should be 0
ValidJSON().eval({}, schema=schema)     # TypeError: multiple values for 'schema'
```

The constructor saves `self.schema` but validation never reads it. Separately, `Scorer.eval()` forwards `expected` positionally, which collides with the `schema` parameter in `ValidJSON._run_eval_sync()`. The same collision affects async partial scorers.

## Changes

- Match the base scorer's `expected` argument slot, preserving the existing second-positional-argument schema convention as a fallback.
- Use the constructor schema when no call-time schema is supplied.
- Keep explicit call-time schemas authoritative, including `{}`, `True`, and `False`; do not mutate the configured schema.
- Add sync, async, callable, partial, parsed-object and JSON-string regression coverage.

This is Python-specific argument plumbing. The TypeScript implementation already receives its schema in the scorer argument object and is unchanged. No scoring algorithm, dependency, or default validation policy changes.

## Validation

- Initial regression run before the fix: 8 failed, 7 passed (constructor schema ignored and duplicate-argument failures).
- Final offline run: **26 passed, 1 deselected**:

```bash
PYTHONPATH=py uv run --no-project --python 3.13 \
  --with polyleven --with chevron --with pyyaml --with jsonschema \
  --with pytest --with pytest-asyncio --with respx -- \
  python -m pytest py/autoevals/test_json.py py/autoevals/test_values.py \
  -k 'not test_list_contains' -q
```

- Changed files pass Black 24.10.0, Ruff, and `git diff --check`.
- `test_list_contains` was excluded after an initial run showed missing optional NumPy/SciPy dependencies. No live-model tests or full suite were run.

AI assistance: implemented and tested with OpenAI Codex.
